### PR TITLE
Add option to specify fields to be fetched

### DIFF
--- a/lib/bookingsync/api/client.rb
+++ b/lib/bookingsync/api/client.rb
@@ -24,8 +24,8 @@ module BookingSync::API
     #
     # @param path [String] The path, relative to {#api_endpoint}
     # @return [Array<Sawyer::Resource>] Array of resources.
-    def get(path)
-      request :get, path
+    def get(path, options = {})
+      request :get, path, options
     end
 
     # Return API endpoint
@@ -39,11 +39,19 @@ module BookingSync::API
 
     # Make a HTTP request to given path
     #
-    # @param method [Symbol] HTTP verb to use
-    # @param path [String] The path, relative to {#api_endpoint}
+    # @param method [Symbol] HTTP verb to use.
+    # @param path [String] The path, relative to {#api_endpoint}.
+    # @param options [Hash] A customizable set of options.
+    # @option options [Array] fields: List of fields to be fetched.
     # @return [Array<Sawyer::Resource>] Array of resources.
-    def request(method, path)
-      response = agent.call(method, path)
+    def request(method, path, options = {})
+      request_options = {}
+      if options.has_key?(:fields)
+        fields = Array(options[:fields]).join(",")
+        request_options[:query] = {fields: fields}
+      end
+
+      response = agent.call(method, path, nil, request_options)
       case response.status
       # fetch objects from outer hash
       # {rentals => [{rental}, {rental}]}

--- a/lib/bookingsync/api/client/bookings.rb
+++ b/lib/bookingsync/api/client/bookings.rb
@@ -3,10 +3,13 @@ module BookingSync::API
     module Bookings
       # List bookings
       #
-      # Return public future bookings for the account user is authenticated with
-      # @return [Array<Sawyer::Resource>] list of bookings
-      def bookings
-        get :bookings
+      # Return public future bookings for the account user
+      # is authenticated with.
+      # @param options [Hash] A customizable set of options.
+      # @option options [Array] fields: List of fields to be fetched.
+      # @return [Array<Sawyer::Resource>] List of bookings.
+      def bookings(options = {})
+        get :bookings, options
       end
     end
   end

--- a/lib/bookingsync/api/client/rentals.rb
+++ b/lib/bookingsync/api/client/rentals.rb
@@ -3,14 +3,18 @@ module BookingSync::API
     module Rentals
       # List rentals
       #
-      # Returns rentals for the account user is authenticated with
-      # @return [Array<Sawyer::Resource>] list of rentals
+      # Returns rentals for the account user is authenticated with.
+      # @param options [Hash] A customizable set of options.
+      # @option options [Array] fields: List of fields to be fetched.
+      # @return [Array<Sawyer::Resource>] List of rentals.
       #
       # @example Get the list of rentals for the current account
       #   rentals = @api.rentals
       #   rentals.first.name # => "Small apartment"
-      def rentals
-        get :rentals
+      # @example Get the list of rentals only with name and description for smaller response
+      #   @api.rentals(fields: [:name, :description])
+      def rentals(options = {})
+        get :rentals, options
       end
     end
   end

--- a/spec/bookingsync/api/client/rentals_spec.rb
+++ b/spec/bookingsync/api/client/rentals_spec.rb
@@ -8,5 +8,13 @@ describe BookingSync::API::Client::Rentals do
       expect(client.rentals).not_to be_nil
       assert_requested :get, bs_url("rentals")
     end
+
+    context "with specified fields in options" do
+      it "returns rentals with filtered fields" do
+        rentals = client.rentals(fields: :name)
+        expect(rentals).not_to be_nil
+        assert_requested :get, bs_url("rentals?fields=name")
+      end
+    end
   end
 end

--- a/spec/bookingsync/api/client_spec.rb
+++ b/spec/bookingsync/api/client_spec.rb
@@ -22,6 +22,7 @@ describe BookingSync::API::Client do
   describe "#request" do
     before { VCR.turn_off! }
     it "authenticates the request with OAuth token" do
+      ENV["ACCESS_TOKEN"] = nil
       stub_get("resource")
       client.get("resource")
       assert_requested :get, bs_url("resource"),
@@ -57,10 +58,19 @@ describe BookingSync::API::Client do
         expect(client.get("resource")).to be_nil
       end
     end
+
+    context "user wants to fetch only specific fields" do
+      it "constructs url for filtered fields" do
+        stub_get("resource?fields=name,description")
+        client.get("resource", fields: [:name, :description])
+        assert_requested :get, bs_url("resource?fields=name,description")
+      end
+    end
   end
 
   describe "#api_endpoint" do
     it "returns URL to the API" do
+      ENV["BOOKINGSYNC_URL"] = nil
       expect(client.api_endpoint).to eql("https://www.bookingsync.com/api/v3")
     end
 

--- a/spec/cassettes/BookingSync_API_Client_Rentals/_rentals/with_specified_fields_in_options/returns_rentals_with_filtered_fields.yml
+++ b/spec/cassettes/BookingSync_API_Client_Rentals/_rentals/with_specified_fields_in_options/returns_rentals_with_filtered_fields.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://www.bookingsync.com/api/v3/rentals?fields=name
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.9.0
+      Accept:
+      - application/vnd.api+json
+      Authorization:
+      - Bearer <<ACCESS_TOKEN>>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Ratelimit-Limit:
+      - '1000'
+      X-Ratelimit-Reset:
+      - '1394208000'
+      X-Ratelimit-Remaining:
+      - '991'
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Request-Method:
+      - "*"
+      Content-Type:
+      - application/vnd.api+json; charset=utf-8
+      X-Ua-Compatible:
+      - IE=Edge
+      Etag:
+      - "\"8bd58448e878aa40ad4737a54ea875a1\""
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      P3p:
+      - CP="OTI DSP COR CUR ADMo DEVo TAI PSAi PSDi IVAi IVDi CONi HISi TELi OTPi
+        OUR SAMi OTRo UNRo PUBi IND UNI STA"
+      X-Request-Id:
+      - d307cea3bd765e0d109b268f8fa8fe3c
+      X-Runtime:
+      - '0.021144'
+      Date:
+      - Fri, 07 Mar 2014 15:38:45 GMT
+      Connection:
+      - close
+    body:
+      encoding: UTF-8
+      string: "{\"rentals\":[{\"name\":\"0 est\"},{\"name\":\"1 et\"}]}"
+    http_version:
+  recorded_at: Fri, 07 Mar 2014 15:38:45 GMT
+recorded_with: VCR 2.8.0

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,9 @@ def test_access_token
 end
 
 def bs_url(path = "")
-  "https://www.bookingsync.com/api/v3/#{path}"
+  # so that it works when running against local BS API
+  url = ENV['BOOKINGSYNC_URL'] || 'https://www.bookingsync.com'
+  "#{url}/api/v3/#{path}"
 end
 
 def stub_get(path, options = {})


### PR DESCRIPTION
It's possible to fetch only some fields from the API.

  @api.rentals(fields: [:name, :description])
  @api.rentals(fields: :photos)

[#66583404]
