### PR TITLE
Get rid of useless class name in edit

### DIFF
--- a/lib/bookingsync/api/client/bookings.rb
+++ b/lib/bookingsync/api/client/bookings.rb
@@ -47,7 +47,7 @@ module BookingSync::API
       # @return [Sawyer::Resource] Updated booking on success, exception is raised otherwise
       # @example
       #   booking = @api.bookings.first
-      #   @api.edit_booking(booking, {adults: 1}) => []
+      #   @api.edit_booking(booking, { adults: 1 })
       def edit_booking(booking, options = {})
         put("bookings/#{booking}", bookings: [options]).pop
       end

--- a/lib/bookingsync/api/client/clients.rb
+++ b/lib/bookingsync/api/client/clients.rb
@@ -34,7 +34,7 @@ module BookingSync::API
       # @return [Sawyer::Resource] Updated client on success, exception is raised otherwise
       # @example
       #   client = @api.clients.first
-      #   @api.edit_client(client, {fullname: "Gary Smith"}) => []
+      #   @api.edit_client(client, { fullname: "Gary Smith" })
       def edit_client(client, options = {})
         put("clients/#{client}", clients: [options]).pop
       end

--- a/lib/bookingsync/api/client/payments.rb
+++ b/lib/bookingsync/api/client/payments.rb
@@ -35,7 +35,7 @@ module BookingSync::API
       # @return [Sawyer::Resource] Updated payment on success, exception is raised otherwise
       # @example
       #   payment = @api.payments.first
-      #   @api.edit_payment(payment, {currency: "EURO"}) => Sawyer::Resource
+      #   @api.edit_payment(payment, { currency: "EURO" })
       def edit_payment(payment, options = {})
         put("payments/#{payment}", payments: [options]).pop
       end

--- a/lib/bookingsync/api/client/periods.rb
+++ b/lib/bookingsync/api/client/periods.rb
@@ -36,7 +36,7 @@ module BookingSync::API
       # exception is raised otherwise
       # @example
       #   period = @api.periods.first
-      #   @api.edit_period(period, { end_at: "2014-04-28" }) => Sawyer::Resource
+      #   @api.edit_period(period, { end_at: "2014-04-28" })
       def edit_period(period, options = {})
         put("periods/#{period}", periods: [options]).pop
       end

--- a/lib/bookingsync/api/client/rates_tables.rb
+++ b/lib/bookingsync/api/client/rates_tables.rb
@@ -35,7 +35,7 @@ module BookingSync::API
       # exception is raised otherwise
       # @example
       #   rates_table = @api.rates_tables.first
-      #   @api.edit_rates_table(rates_table, { name: "Lorem" }) => Sawyer::Resource
+      #   @api.edit_rates_table(rates_table, { name: "Lorem" })
       def edit_rates_table(rates_table, options = {})
         put("rates_tables/#{rates_table}", rates_tables: [options]).pop
       end

--- a/lib/bookingsync/api/client/rentals.rb
+++ b/lib/bookingsync/api/client/rentals.rb
@@ -34,7 +34,7 @@ module BookingSync::API
       # @return [Sawyer::Resource] Updated rental on success, exception is raised otherwise
       # @example
       #   rental = @api.rentals.first
-      #   @api.edit_rental(rental, { sleeps: 3 }) => Sawyer::Resource
+      #   @api.edit_rental(rental, { sleeps: 3 })
       def edit_rental(rental, options = {})
         put("rentals/#{rental}", rentals: [options]).pop
       end

--- a/lib/bookingsync/api/client/seasons.rb
+++ b/lib/bookingsync/api/client/seasons.rb
@@ -1,6 +1,6 @@
 module BookingSync::API
   class Client
-    module Seasons 
+    module Seasons
       # List seasons
       #
       # Returns seasons for the account user is authenticated with.
@@ -35,7 +35,7 @@ module BookingSync::API
       # @return [Sawyer::Resource] Updated season on success, exception is raised otherwise
       # @example
       #   season = @api.seasons.first
-      #   @api.edit_season(season, { name: "Some season" }) => Sawyer::Resource
+      #   @api.edit_season(season, { name: "Some season" })
       def edit_season(season, options = {})
         put("seasons/#{season}", seasons: [options]).pop
       end

--- a/lib/bookingsync/api/client/special_offers.rb
+++ b/lib/bookingsync/api/client/special_offers.rb
@@ -29,14 +29,14 @@ module BookingSync::API
 
       # Edit a special_offer
       #
-      # @param special_offer [Sawyer::Resource|Integer] special offer or 
+      # @param special_offer [Sawyer::Resource|Integer] special offer or
       # ID of the special offer to be updated
       # @param options [Hash] special offer attributes to be updated
       # @return [Sawyer::Resource] Updated special offer on success,
       # exception is raised otherwise
       # @example
       #   special_offer = @api.special_offers.first
-      #   @api.edit_special_offer(special_offer, {name: "New offer"}) => Sawyer::Resource
+      #   @api.edit_special_offer(special_offer, { name: "New offer" })
       def edit_special_offer(special_offer, options = {})
         put("special_offers/#{special_offer}", special_offers: [options]).pop
       end


### PR DESCRIPTION
Fix hash style

No need for specifying there class of a returned object, it's in the @return param. 
