### PR TITLE
Improved handling errors responses from API

### DIFF
--- a/lib/bookingsync/api/client.rb
+++ b/lib/bookingsync/api/client.rb
@@ -287,9 +287,9 @@ module BookingSync::API
       case response.status
       when 204; nil # destroy/cancel
       when 200..299; response
-      when 401; raise Unauthorized.new
-      when 404; raise NotFound.new
-      when 422; raise UnprocessableEntity.new
+      when 401; raise Unauthorized.new(response)
+      when 404; raise NotFound.new(response)
+      when 422; raise UnprocessableEntity.new(response)
       else raise UnsupportedResponse.new(response)
       end
     end

--- a/lib/bookingsync/api/error.rb
+++ b/lib/bookingsync/api/error.rb
@@ -1,11 +1,6 @@
 module BookingSync::API
   # Class for rescuing all BS API errors
-  class Error < StandardError; end
-  class Unauthorized < Error; end
-  class UnprocessableEntity < Error; end
-  class NotFound < Error; end
-
-  class UnsupportedResponse < Error
+  class Error < StandardError
     attr_reader :status, :headers, :body
 
     def initialize(response)
@@ -14,11 +9,20 @@ module BookingSync::API
       @body    = response.body
     end
 
-    def message
-      %Q{Received unsupported response from BookingSync API
+    def message(message = self.class)
+      %Q{#{message}
 HTTP status code : #{status}
 Headers          : #{headers}
 Body             : #{body}}
+    end
+  end
+
+  class Unauthorized < Error; end
+  class UnprocessableEntity < Error; end
+  class NotFound < Error; end
+  class UnsupportedResponse < Error
+    def message
+      super("Received unsupported response from BookingSync API")
     end
   end
 end

--- a/spec/bookingsync/api/error_spec.rb
+++ b/spec/bookingsync/api/error_spec.rb
@@ -1,0 +1,46 @@
+require "spec_helper"
+
+describe BookingSync::API::Error do
+  let(:client) { BookingSync::API::Client.new(test_access_token) }
+  before do
+    stub_get("resource", status: 422, body:
+      { errors: { name: ["can't be blank"] } }.to_json)
+  end
+  let(:request) { client.get("resource") }
+
+  describe "#status" do
+    it "returns HTTP status of the response" do
+      expect { request }.to raise_error(BookingSync::API::Error) { |exception|
+        expect(exception.status).to eq 422
+      }
+    end
+  end
+
+  describe "#body" do
+    it "returns response body" do
+      expect { request }.to raise_error(BookingSync::API::Error) { |exception|
+        expect(exception.body).to eq '{"errors":{"name":["can\'t be blank"]}}'
+      }
+    end
+  end
+
+  describe "#headers" do
+    it "returns response headers" do
+      expect { request }.to raise_error(BookingSync::API::Error) { |exception|
+        expect(exception.headers).to eq({"content-type" =>
+          "application/vnd.api+json"})
+      }
+    end
+  end
+
+  describe "#message" do
+    it "returns standard exception message" do
+      expect { request }.to raise_error(BookingSync::API::Error) { |exception|
+        expect(exception.message).to eq(%Q{BookingSync::API::UnprocessableEntity
+HTTP status code : 422
+Headers          : {"content-type"=>"application/vnd.api+json"}
+Body             : {"errors":{"name":["can't be blank"]}}})
+      }
+    end
+  end
+end


### PR DESCRIPTION
Now response body is always displayed on exception. All errors
expose basic info about response, like HTTP headers, body and status.
