### PR TITLE
Unify syntax to eq

### DIFF
--- a/spec/bookingsync/api/client/amenities_spec.rb
+++ b/spec/bookingsync/api/client/amenities_spec.rb
@@ -19,7 +19,7 @@ describe BookingSync::API::Client::Amenities do
 
     it "returns amenity" do
       amenity = client.amenity(prefetched_amenity[:id])
-      expect(amenity.title).to eql(prefetched_amenity[:title])
+      expect(amenity.title).to eq(prefetched_amenity[:title])
     end
   end
 end

--- a/spec/bookingsync/api/client/bathrooms_spec.rb
+++ b/spec/bookingsync/api/client/bathrooms_spec.rb
@@ -41,8 +41,8 @@ describe BookingSync::API::Client::Bathrooms do
     it "returns newly created bathroom" do
       VCR.use_cassette("BookingSync_API_Client_Bathrooms/_create_bathroom/creates_a_new_bathroom") do
         bathroom = client.create_bathroom(rental, attributes)
-        expect(bathroom.name).to eql(en: "New bathroom")
-        expect(bathroom.wc_count).to eql(attributes[:wc_count])
+        expect(bathroom.name).to eq(en: "New bathroom")
+        expect(bathroom.wc_count).to eq(attributes[:wc_count])
       end
     end
   end

--- a/spec/bookingsync/api/client/bedrooms_spec.rb
+++ b/spec/bookingsync/api/client/bedrooms_spec.rb
@@ -41,8 +41,8 @@ describe BookingSync::API::Client::Bedrooms do
     it "returns newly created bedroom" do
       VCR.use_cassette("BookingSync_API_Client_Bedrooms/_create_bedroom/creates_a_new_bedroom") do
         bedroom = client.create_bedroom(rental, attributes)
-        expect(bedroom.name).to eql(en: "New bedroom")
-        expect(bedroom.sofa_beds_count).to eql(attributes[:sofa_beds_count])
+        expect(bedroom.name).to eq(en: "New bedroom")
+        expect(bedroom.sofa_beds_count).to eq(attributes[:sofa_beds_count])
       end
     end
   end

--- a/spec/bookingsync/api/client/bookings_spec.rb
+++ b/spec/bookingsync/api/client/bookings_spec.rb
@@ -15,7 +15,7 @@ describe BookingSync::API::Client::Bookings do
       context "with per_page setting" do
         it "returns limited number of bookings" do
           bookings = client.bookings(per_page: 2)
-          expect(bookings.size).to eql(2)
+          expect(bookings.size).to eq(2)
         end
       end
 
@@ -24,7 +24,7 @@ describe BookingSync::API::Client::Bookings do
           sizes = [2, 2]
           index = 0
           client.bookings(per_page: 2) do |bookings|
-            expect(bookings.size).to eql(sizes[index])
+            expect(bookings.size).to eq(sizes[index])
             index += 1
           end
         end
@@ -33,7 +33,7 @@ describe BookingSync::API::Client::Bookings do
       context "with auto_paginate: true" do
         it "returns all bookings joined from many requests" do
           bookings = client.bookings(per_page: 2, auto_paginate: true)
-          expect(bookings.size).to eql(4)
+          expect(bookings.size).to eq(4)
         end
       end
     end
@@ -73,8 +73,8 @@ describe BookingSync::API::Client::Bookings do
     it "returns newly created booking" do
       VCR.use_cassette("BookingSync_API_Client_Bookings/_create_booking/creates_a_booking") do
         booking = client.create_booking(rental, attributes)
-        expect(booking.links.account).to eql(3837)
-        expect(booking.links.rental).to eql(rental.id)
+        expect(booking.links.account).to eq(3837)
+        expect(booking.links.rental).to eq(rental.id)
       end
     end
   end

--- a/spec/bookingsync/api/client/inquiries_spec.rb
+++ b/spec/bookingsync/api/client/inquiries_spec.rb
@@ -45,8 +45,8 @@ describe BookingSync::API::Client::Inquiries do
     it "returns newly created inquiry" do
       VCR.use_cassette("BookingSync_API_Client_Inquiries/_create_inquiry/creates_a_new_inquiry") do
         inquiry = client.create_inquiry(rental, attributes)
-        expect(inquiry.links.rental).to eql(rental.id)
-        expect(inquiry.firstname).to eql("John")
+        expect(inquiry.links.rental).to eq(rental.id)
+        expect(inquiry.firstname).to eq("John")
       end
     end
   end

--- a/spec/bookingsync/api/client/payments_spec.rb
+++ b/spec/bookingsync/api/client/payments_spec.rb
@@ -39,8 +39,8 @@ describe BookingSync::API::Client::Payments do
     it "returns newly created payment" do
       VCR.use_cassette("BookingSync_API_Client_Payments/_create_payment/creates_a_new_payment") do
         payment = api.create_payment(booking_id, attributes)
-        expect(payment.amount_in_cents).to eql(200)
-        expect(payment.kind).to eql("cash")
+        expect(payment.amount_in_cents).to eq(200)
+        expect(payment.kind).to eq("cash")
       end
     end
   end

--- a/spec/bookingsync/api/client/periods_spec.rb
+++ b/spec/bookingsync/api/client/periods_spec.rb
@@ -38,8 +38,8 @@ describe BookingSync::API::Client::Periods do
     it "returns newly created period" do
       VCR.use_cassette("BookingSync_API_Client_Periods/_create_period/creates_a_new_period") do
         period = client.create_period(season, attributes)
-        expect(period.start_date).to eql(Time.parse(attributes[:start_date]))
-        expect(period.end_date).to eql(Time.parse(attributes[:end_date]))
+        expect(period.start_date).to eq(Time.parse(attributes[:start_date]))
+        expect(period.end_date).to eq(Time.parse(attributes[:end_date]))
       end
     end
   end

--- a/spec/bookingsync/api/client/rates_rules_spec.rb
+++ b/spec/bookingsync/api/client/rates_rules_spec.rb
@@ -44,8 +44,8 @@ describe BookingSync::API::Client::RatesRules do
     it "returns newly created rates_rule" do
       VCR.use_cassette("BookingSync_API_Client_RatesRules/_create_rates_rule/creates_a_new_rates_rule") do
         rates_rule = client.create_rates_rule(rates_table, attributes)
-        expect(rates_rule.start_date).to eql(Time.parse(attributes[:start_date]))
-        expect(rates_rule.end_date).to eql(Time.parse(attributes[:end_date]))
+        expect(rates_rule.start_date).to eq(Time.parse(attributes[:start_date]))
+        expect(rates_rule.end_date).to eq(Time.parse(attributes[:end_date]))
       end
     end
   end

--- a/spec/bookingsync/api/client/rates_tables_spec.rb
+++ b/spec/bookingsync/api/client/rates_tables_spec.rb
@@ -37,7 +37,7 @@ describe BookingSync::API::Client::RatesTables do
     it "returns newly created rates_table" do
       VCR.use_cassette("BookingSync_API_Client_RatesTables/_create_rates_table/creates_a_new_rates_table") do
         rates_table = client.create_rates_table(attributes)
-        expect(rates_table.name).to eql(attributes[:name])
+        expect(rates_table.name).to eq(attributes[:name])
       end
     end
   end
@@ -60,7 +60,7 @@ describe BookingSync::API::Client::RatesTables do
       VCR.use_cassette("BookingSync_API_Client_RatesTables/_edit_rates_table/updates_given_rates_table_by_ID") do
         rates_table = client.edit_rates_table(created_rates_table_id, attributes)
         expect(rates_table).to be_kind_of(BookingSync::API::Resource)
-        expect(rates_table.name).to eql(attributes[:name])
+        expect(rates_table.name).to eq(attributes[:name])
       end
     end
   end

--- a/spec/bookingsync/api/client/rental_agreements_spec.rb
+++ b/spec/bookingsync/api/client/rental_agreements_spec.rb
@@ -36,7 +36,7 @@ describe BookingSync::API::Client::RentalAgreements do
     it "returns newly created rental agreement" do
       VCR.use_cassette("BookingSync_API_Client_RentalAgreements/_create_rental_agreement/creates_a_new_rental_agreement") do
         rental_agreement = client.create_rental_agreement(attributes)
-        expect(rental_agreement.body).to eql(attributes[:body])
+        expect(rental_agreement.body).to eq(attributes[:body])
       end
     end
   end
@@ -55,7 +55,7 @@ describe BookingSync::API::Client::RentalAgreements do
     it "returns newly created rental agreement" do
       VCR.use_cassette("BookingSync_API_Client_RentalAgreements/_create_rental_agreement_for_booking/creates_a_new_rental_agreement") do
         rental_agreement = client.create_rental_agreement_for_booking(booking, attributes)
-        expect(rental_agreement.body).to eql(attributes[:body])
+        expect(rental_agreement.body).to eq(attributes[:body])
       end
     end
   end
@@ -74,7 +74,7 @@ describe BookingSync::API::Client::RentalAgreements do
     it "returns newly created rental agreement" do
       VCR.use_cassette("BookingSync_API_Client_RentalAgreements/_create_rental_agreement_for_rental/creates_a_new_rental_agreement") do
         rental_agreement = client.create_rental_agreement_for_rental(rental, attributes)
-        expect(rental_agreement.body).to eql(attributes[:body])
+        expect(rental_agreement.body).to eq(attributes[:body])
       end
     end
   end

--- a/spec/bookingsync/api/client/rentals_spec.rb
+++ b/spec/bookingsync/api/client/rentals_spec.rb
@@ -15,7 +15,7 @@ describe BookingSync::API::Client::Rentals do
       rental_ids = find_resources("#{@casette_base_path}_rentals/returns_rentals.yml", "rentals").map { |r| r["id"] }[0..1]
 
       rentals = client.rentals(ids: rental_ids)
-      expect(rentals.size).to eql(2)
+      expect(rentals.size).to eq(2)
       assert_requested :get, bs_url("rentals/#{rental_ids.join(',')}")
     end
 
@@ -64,7 +64,7 @@ describe BookingSync::API::Client::Rentals do
 
     it "returns a single rental" do
       rental = client.rental(prefetched_rental[:id])
-      expect(rental.name).to eql(prefetched_rental[:name])
+      expect(rental.name).to eq(prefetched_rental[:name])
     end
   end
 
@@ -80,8 +80,8 @@ describe BookingSync::API::Client::Rentals do
     it "returns newly created rental" do
       VCR.use_cassette("BookingSync_API_Client_Rentals/_create_rental/creates_a_new_rental") do
         rental = client.create_rental(attributes)
-        expect(rental.name).to eql("New rental")
-        expect(rental.sleeps).to eql(2)
+        expect(rental.name).to eq("New rental")
+        expect(rental.sleeps).to eq(2)
       end
     end
   end

--- a/spec/bookingsync/api/client/reviews_spec.rb
+++ b/spec/bookingsync/api/client/reviews_spec.rb
@@ -36,8 +36,8 @@ describe BookingSync::API::Client::Reviews do
     it "returns newly created review" do
       VCR.use_cassette("BookingSync_API_Client_Reviews/_create_review/creates_a_new_review") do
         review = client.create_review(booking, attributes)
-        expect(review.comment).to eql(attributes[:comment])
-        expect(review.rating).to eql(attributes[:rating])
+        expect(review.comment).to eq(attributes[:comment])
+        expect(review.rating).to eq(attributes[:rating])
       end
     end
   end

--- a/spec/bookingsync/api/client/seasons_spec.rb
+++ b/spec/bookingsync/api/client/seasons_spec.rb
@@ -38,8 +38,8 @@ describe BookingSync::API::Client::Seasons do
     it "returns newly created season" do
       VCR.use_cassette("BookingSync_API_Client_Seasons/_create_season/creates_a_new_season") do
         season = client.create_season(rates_table, attributes)
-        expect(season.name).to eql(en: attributes[:name])
-        expect(season.minimum_stay).to eql(attributes[:minimum_stay])
+        expect(season.name).to eq(en: attributes[:name])
+        expect(season.minimum_stay).to eq(attributes[:minimum_stay])
       end
     end
   end

--- a/spec/bookingsync/api/client/sources_spec.rb
+++ b/spec/bookingsync/api/client/sources_spec.rb
@@ -37,7 +37,7 @@ describe BookingSync::API::Client::Sources do
     it "returns newly created source" do
       VCR.use_cassette("BookingSync_API_Client_Sources/_create_source/creates_a_new_source") do
         source = client.create_source(attributes)
-        expect(source.name).to eql(attributes[:name])
+        expect(source.name).to eq(attributes[:name])
       end
     end
   end
@@ -60,7 +60,7 @@ describe BookingSync::API::Client::Sources do
       VCR.use_cassette("BookingSync_API_Client_Sources/_edit_source/updates_given_source_by_ID") do
         source = client.edit_source(created_source_id, attributes)
         expect(source).to be_kind_of(BookingSync::API::Resource)
-        expect(source.name).to eql(attributes[:name])
+        expect(source.name).to eq(attributes[:name])
       end
     end
   end

--- a/spec/bookingsync/api/client/special_offers_spec.rb
+++ b/spec/bookingsync/api/client/special_offers_spec.rb
@@ -45,7 +45,7 @@ describe BookingSync::API::Client::SpecialOffers do
     it "returns newly created special_offer" do
       VCR.use_cassette("BookingSync_API_Client_SpecialOffers/_create_special_offer/creates_a_new_special_offer") do
         special_offer = client.create_special_offer(rental, attributes)
-        expect(special_offer.name).to eql(en: attributes[:name_en])
+        expect(special_offer.name).to eq(en: attributes[:name_en])
       end
     end
   end

--- a/spec/bookingsync/api/client/strict_bookings_spec.rb
+++ b/spec/bookingsync/api/client/strict_bookings_spec.rb
@@ -37,8 +37,8 @@ describe BookingSync::API::Client::StrictBookings do
     it "returns newly created booking" do
      VCR.use_cassette("BookingSync_API_Client_StrictBookings/_create_strict_booking/creates_a_booking") do
        booking = client.create_strict_booking(params)
-       expect(booking.start_at).to eql(Time.parse("2017-05-22 16:00:00 UTC"))
-       expect(booking.end_at).to eql(Time.parse("2017-05-29 10:00:00 UTC"))
+       expect(booking.start_at).to eq(Time.parse("2017-05-22 16:00:00 UTC"))
+       expect(booking.end_at).to eq(Time.parse("2017-05-29 10:00:00 UTC"))
      end
    end
   end

--- a/spec/bookingsync/api/client_spec.rb
+++ b/spec/bookingsync/api/client_spec.rb
@@ -6,7 +6,7 @@ describe BookingSync::API::Client do
   describe "#new" do
     it "initializes client object with given token" do
       client = BookingSync::API::Client.new("xyz")
-      expect(client.token).to eql("xyz")
+      expect(client.token).to eq("xyz")
     end
   end
 
@@ -80,7 +80,7 @@ describe BookingSync::API::Client do
         response = double(BookingSync::API::Response)
         allow(client).to receive(:call) { response }
         resources = client.request(:get, "resource")
-        expect(resources).to eql(response)
+        expect(resources).to eq(response)
       end
     end
   end
@@ -167,7 +167,7 @@ describe BookingSync::API::Client do
         expect {
           client.get("resource")
         }.to raise_error(BookingSync::API::UnsupportedResponse) { |error|
-          expect(error.status).to eql(405)
+          expect(error.status).to eq(405)
           expect(error.headers).to eq("content-type" => "application/vnd.api+json")
           expect(error.body).to eq("Whoops!")
           expect(error.message).to include("Received unsupported response from BookingSync API")
@@ -216,7 +216,7 @@ describe BookingSync::API::Client do
   describe "#api_endpoint" do
     it "returns URL to the API" do
       ENV["BOOKINGSYNC_URL"] = nil
-      expect(client.api_endpoint).to eql("https://www.bookingsync.com/api/v3")
+      expect(client.api_endpoint).to eq("https://www.bookingsync.com/api/v3")
     end
 
     context "user specifies base URL via BOOKINGSYNC_URL env" do
@@ -229,7 +229,7 @@ describe BookingSync::API::Client do
       end
 
       it "returns custom URL to the API" do
-        expect(client.api_endpoint).to eql("https://bookingsync.dev/api/v3")
+        expect(client.api_endpoint).to eq("https://bookingsync.dev/api/v3")
       end
     end
   end
@@ -275,7 +275,7 @@ describe BookingSync::API::Client do
     it "returns last response" do
       stub_get("resources", body: { meta: { count: 10 }, resources: [] }.to_json)
       client.get("resources")
-      expect(client.last_response.meta).to eql(count: 10)
+      expect(client.last_response.meta).to eq(count: 10)
     end
   end
 
@@ -288,7 +288,7 @@ describe BookingSync::API::Client do
     describe "#pagination_first_response" do
       it "returns first response of a paginated call" do
         client.paginate("resources", auto_paginate: true)
-        expect(client.pagination_first_response.meta).to eql(text: "first request")
+        expect(client.pagination_first_response.meta).to eq(text: "first request")
       end
     end
   end

--- a/spec/bookingsync/api/relation_spec.rb
+++ b/spec/bookingsync/api/relation_spec.rb
@@ -13,7 +13,7 @@ describe BookingSync::API::Relation do
   describe ".from_links" do
     it "returns a hash of relations" do
       relations = BookingSync::API::Relation.from_links(client, links)
-      expect(relations.size).to eql(1)
+      expect(relations.size).to eq(1)
       expect(relations).to be_kind_of(Hash)
       expect(relations["foo.photos"]).to be_kind_of(BookingSync::API::Relation)
     end

--- a/spec/bookingsync/api/resource_spec.rb
+++ b/spec/bookingsync/api/resource_spec.rb
@@ -26,17 +26,17 @@ describe BookingSync::API::Resource do
 
   describe "processing values" do
     it "makes data accessible" do
-      expect(resource.name).to eql("foo")
-      expect(resource.width).to eql(700)
+      expect(resource.name).to eq("foo")
+      expect(resource.width).to eq(700)
     end
 
     it "makes nested data accessible" do
-      expect(resource.details.count).to eql(1)
+      expect(resource.details.count).to eq(1)
     end
 
     describe "#_resources_key" do
       it "returns resources_key" do
-        expect(resource._resources_key).to eql("foo")
+        expect(resource._resources_key).to eq("foo")
       end
 
       context "for nested resource" do
@@ -54,7 +54,7 @@ describe BookingSync::API::Resource do
       it "fetches an association based on links" do
         stub_request(:get, "http://foo.com/photos/9,10")
           .to_return(body: { photos: [{ file: "a.jpg" }] }.to_json)
-        expect(resource.photos).to eql([{ file: "a.jpg" }])
+        expect(resource.photos).to eq([{ file: "a.jpg" }])
       end
     end
 
@@ -63,7 +63,7 @@ describe BookingSync::API::Resource do
       it "fetches an association based on links" do
         stub_request(:get, "http://foo.com/categories/15")
           .to_return(body: { categories: [{ name: "Secret one" }] }.to_json)
-        expect(resource.category).to eql([{ name: "Secret one" }])
+        expect(resource.category).to eq([{ name: "Secret one" }])
       end
     end
 
@@ -76,14 +76,14 @@ describe BookingSync::API::Resource do
       it "fetches association based on links and type" do
         stub_request(:get, "http://foo.com/articles/15")
           .to_return(body: { articles: [{ name: "Secret one" }] }.to_json)
-        expect(resource.taggable).to eql([{ name: "Secret one" }])
+        expect(resource.taggable).to eq([{ name: "Secret one" }])
       end
     end
 
     context "when there are not associated ids" do
       let(:links) { { photos: [] } }
       it "returns an empty array" do
-        expect(resource.photos).to eql([])
+        expect(resource.photos).to eq([])
       end
     end
 

--- a/spec/bookingsync/api/response_spec.rb
+++ b/spec/bookingsync/api/response_spec.rb
@@ -35,13 +35,13 @@ describe BookingSync::API::Response do
 
   describe "#resources_key" do
     it "returns name of the hash key where resources are" do
-      expect(response.resources_key).to eql(:rentals)
+      expect(response.resources_key).to eq(:rentals)
     end
   end
 
   describe "#resources" do
     it "returns an array of resources" do
-      expect(response.resources).to eql(rentals)
+      expect(response.resources).to eq(rentals)
     end
   end
 
@@ -55,26 +55,26 @@ describe BookingSync::API::Response do
 
   describe "#status" do
     it "returns HTTP response status" do
-      expect(response.status).to eql(200)
+      expect(response.status).to eq(200)
     end
   end
 
   describe "#headers" do
     it "returns HTTP response headers" do
-      expect(response.headers).to eql(headers)
+      expect(response.headers).to eq(headers)
     end
   end
 
   describe "#relations" do
     it "returns relations from Link header" do
-      expect(response.relations[:next].href).to eql("/rentals?page=2")
-      expect(response.relations[:last].href).to eql("/rentals?page=19")
+      expect(response.relations[:next].href).to eq("/rentals?page=2")
+      expect(response.relations[:last].href).to eq("/rentals?page=19")
     end
   end
 
   describe "#meta" do
     it "returns meta information from response body" do
-      expect(response.meta).to eql(count: 10)
+      expect(response.meta).to eq(count: 10)
     end
   end
 end


### PR DESCRIPTION
I didn't see any places where `eql` would be absolutely essential, so looks like it's ok to replace it everywhere with `eq`.
Closes #106 