### PR TITLE
Override client headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# master
+
+- Enable dynamic override of headers per request.
+
 ## 0.1.8 - 2017-12-05
 
 - Add support for `bookings_tags` endpoint.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,19 @@ api.last_response.meta # => {"deleted_ids" => [1, 3, 4]}
 api.pagination_first_response.meta # => {"deleted_ids" => [1, 3, 4]}
 ```
 
+### Adjust headers dynamically
+
+If you need to add custom headers you can use `#with_headers` method. It accepts hash of headers
+that should be added to next request and yields client. It resets headers to default ones at the end
+and returns result of last operation specified inside block.
+
+```ruby
+api.with_headers("x-awesome-header" => "you-bet-i-am") do |adjusted_api_client|
+  adjusted_api_client.rentals
+end
+=> [BookingSync::API::Resource, BookingSync::API::Resource]
+```
+
 ### Logging
 
 Sometimes it's useful to see what data bookingsync-api gem sends and what it

--- a/lib/bookingsync/api/client.rb
+++ b/lib/bookingsync/api/client.rb
@@ -280,6 +280,19 @@ module BookingSync::API
       end
     end
 
+    # Yields client with temporarily modified headers.
+    #
+    # @param extra_headers [Hash] Additional headers added to next request.
+    # @yieldreturn [BookingSync::API::Client] Client with modified default headers.
+    # @return [Array<BookingSync::API::Resource>|BookingSync::API::Resource|String|Object] Client response
+    def with_headers(extra_headers = {}, &block)
+      original_headers = @conn.headers.dup
+      @conn.headers.merge!(extra_headers)
+      result = yield self
+      @conn.headers = original_headers
+      result
+    end
+
     private
 
     def middleware

--- a/spec/bookingsync/api/client_spec.rb
+++ b/spec/bookingsync/api/client_spec.rb
@@ -309,7 +309,7 @@ describe BookingSync::API::Client do
     end
   end
 
-  fdescribe "with_headers" do
+  describe "with_headers" do
     it "makes request with modified headers but resets to original headers at the end" do
       stub_get("resource")
       client.with_headers("x-awesome-header" => "you-bet-i-am") do |adjusted_api_client|

--- a/spec/bookingsync/api/client_spec.rb
+++ b/spec/bookingsync/api/client_spec.rb
@@ -308,4 +308,46 @@ describe BookingSync::API::Client do
       end
     end
   end
+
+  fdescribe "with_headers" do
+    it "makes request with modified headers but resets to original headers at the end" do
+      stub_get("resource")
+      client.with_headers("x-awesome-header" => "you-bet-i-am") do |adjusted_api_client|
+        adjusted_api_client.get("resource")
+      end
+      assert_requested(:get, bs_url("resource")) do |request|
+        request.headers["X-Awesome-Header"] == "you-bet-i-am"
+      end
+
+      client.get("resource")
+      assert_requested(:get, bs_url("resource")) do |request|
+        !request.headers.key?("X-Awesome-Header")
+      end
+    end
+
+    it "properly brings back original headers even if it was overriden" do
+      stub_get("resource")
+      client.with_headers("Content-Type" => "another-content-type") do |adjusted_api_client|
+        adjusted_api_client.get("resource")
+      end
+      assert_requested(:get, bs_url("resource")) do |request|
+        request.headers["Content-Type"] == "another-content-type"
+      end
+
+      client.get("resource")
+      assert_requested(:get, bs_url("resource")) do |request|
+        request.headers["Content-Type"] == BookingSync::API::Client::MEDIA_TYPE
+      end
+    end
+
+    it "returns result of method called on adjusted client" do
+      stub_get("resource", body: { resources: [{ name: "Megan" }] }.to_json)
+      resources = client.with_headers("x-awesome-header" => "you-bet-i-am") do |adjusted_api_client|
+        adjusted_api_client.get("resource")
+      end
+      expect(resources).to be_kind_of(Array)
+      expect(resources.first).to be_a BookingSync::API::Resource
+      expect(resources.first.name).to eq("Megan")
+    end
+  end
 end


### PR DESCRIPTION
This allows to dynamically assign extra headers  for every request