### PR TITLE
Test against ruby 2.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - "2.1"
   - "2.2"
+  - "2.4.4"
   - "2.5.1"
 before_install:
   - gem install bundler -v 1.12.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: ruby
 rvm:
   - "2.1"
   - "2.2"
+  - "2.5.1"
 before_install:
   - gem install bundler -v 1.12.5
 script:
-  - bundle exec rake style:rubocop:without_auto_correct 
+  - bundle exec rake style:rubocop:without_auto_correct
   - bundle exec rake spec

--- a/lib/bookingsync/api/client.rb
+++ b/lib/bookingsync/api/client.rb
@@ -415,5 +415,9 @@ module BookingSync::API
     def next_page(response, request_settings)
       response.relations[:next].call({}, { method: request_settings[:request_method] })
     end
+
+    def reject_blank_values(array)
+      array.reject { |value| value.nil? || value == "" }
+    end
   end
 end

--- a/lib/bookingsync/api/client/rentals.rb
+++ b/lib/bookingsync/api/client/rentals.rb
@@ -30,7 +30,7 @@ module BookingSync::API
       # villas = @api.rentals_search(rental_type: "villa")
       def rentals_search(options = {}, &block)
         ids = Array(options.delete(:ids))
-        path = ["rentals", ids.join(","), "search"].compact.join("/")
+        path = reject_blank_values(["rentals", ids.join(","), "search"]).join("/")
         defaults = { request_method: :post }
         paginate path, defaults.merge(options), &block
       end
@@ -79,7 +79,8 @@ module BookingSync::API
       # @param rentals [Array] IDs of Rentals, leave empty for all account's rentals
       # @return [BookingSync::API::Resource]
       def rentals_meta(rentals = nil)
-        get(["rentals", Array(rentals).join(","), "meta"].compact.join("/")).pop
+        path = reject_blank_values(["rentals", Array(rentals).join(","), "meta"]).join("/")
+        get(path).pop
       end
     end
   end


### PR DESCRIPTION
Ruby used to 'normalize' url but reducing double slash to single one. It changed in ruby 2.5 which caused some vcrs to get broken due to url mismatch. 
This PR aims to solve it be rejecting blank values which will allow to generate single slash urls. 