### PR TITLE
Fix Link to Gem Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ When using `BOOKINGSYNC_API_DEBUG` variable, log level is DEBUG.
 
 ## Gem documentation
 
-See [gem documentation](http://rdoc.info/github/BookingSync/bookingsync-api/master/frames) for more info.
+See [gem documentation](https://www.rubydoc.info/gems/bookingsync-api/) for more info.
 
 ## API documentation
 


### PR DESCRIPTION
The link to the Gem documentation was not working.
Here is my attempt to fix it.